### PR TITLE
Fix ts version (2.5.3 doesn't work now)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-typescript": "^2.13.6",
     "through2": "^2.0.1",
     "tslint": "^3.7.3",
-    "typescript": "^2.0.2",
+    "typescript": "2.0.2",
     "upath": "^0.2.0"
   }
 }


### PR DESCRIPTION
Bonjour,
Nous faisons actuellement le TP "multi-touches" et la derniere version (`2.5.3`) de `typescript` (sortie [il y a une semaine](https://www.npmjs.com/package/typescript)) rend une erreur lors de l'execution de `gulp`.

Enlever le ^ dans le package.json permet de fixer la version de la dépendance à `2.0.2` en attendant.

La stacktrace:
```
> gulp default
[10:20:03] Using gulpfile ~/Polytech/IHM/TP2/gulpfile.js
[10:20:03] Starting 'lint'...
linterPipeline [ 'ts/**/*.ts' ]
[10:20:03] Starting 'tsc'...
[10:20:03] Finished 'tsc' after 43 ms
internal/streams/legacy.js:59
      throw er; // Unhandled stream error in pipe.
      ^

Error: Unsupported TypeScript version: 2.5.3
    at Object.current (/Users/antoine/Polytech/IHM/TP2/node_modules/codelyzer/util/syntaxKind.js:1796:23)
    at ConstructorMetadataWalker.visitConstructorDeclaration (/Users/antoine/Polytech/IHM/TP2/node_modules/codelyzer/noAttributeParameterDecoratorRule.js:31:37)
    at ConstructorMetadataWalker.SyntaxWalker.visitNode (/Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:276:22)
    at /Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:459:63
    at visitNodes (/Users/antoine/Polytech/IHM/TP2/node_modules/typescript/lib/typescript.js:11911:30)
    at Object.forEachChild (/Users/antoine/Polytech/IHM/TP2/node_modules/typescript/lib/typescript.js:12162:21)
    at ConstructorMetadataWalker.SyntaxWalker.walkChildren (/Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:459:12)
    at ConstructorMetadataWalker.SyntaxWalker.visitClassDeclaration (/Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:43:14)
    at ConstructorMetadataWalker.SyntaxWalker.visitNode (/Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:264:22)
    at /Users/antoine/Polytech/IHM/TP2/node_modules/tslint/lib/language/walker/syntaxWalker.js:459:63
```

Nous sommes plusieurs à avoir cette erreur, mais pas tous (ça fonctionne surement chez ceux qui avait une version de `typescript` en cache)